### PR TITLE
feat(interviews): preserve specific scheduling when creating next stage

### DIFF
--- a/Interviews/Views/CreateNextStageView.swift
+++ b/Interviews/Views/CreateNextStageView.swift
@@ -194,6 +194,13 @@ struct CreateNextStageView: View {
         interview.outcome = .passed
         interview.updatedAt = Date()
         
+        let newOutcome: InterviewOutcome?
+        if hasSpecificDate {
+            newOutcome = .scheduled
+        } else {
+            newOutcome = nil
+        }
+        
         // Create new interview with next stage
         let newInterview = Interview(
             company: interview.company,
@@ -206,7 +213,7 @@ struct CreateNextStageView: View {
             userId: interview.userId,
             date: hasSpecificDate ? interviewDate : nil,
             deadline: hasDeadline ? deadline : nil,
-            outcome: .awaitingResponse, // New stage is awaiting response
+            outcome: newOutcome,
             notes: notes.isEmpty ? nil : notes,
             link: link.isEmpty ? nil : link,
             jobListing: interview.jobListing // Carry over job posting link


### PR DESCRIPTION
When marking an interview as passed and creating the next stage, preserve an
explicit scheduled outcome if the user provided a specific date. Previously
the new interview always defaulted to .awaitingResponse, losing the
scheduled status when a date was set. Now the code sets outcome to .scheduled
when hasSpecificDate is true, otherwise leaves it nil. This keeps the
intended state for newly created interviews and avoids overwriting explicit
scheduling.