### PR TITLE
chore: bump Swift tools version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Update Package.swift to declare swift-tools-version 6.0 at the
top of the manifest.

This change ensures the package is built with Swift 6 toolchain
features and compatibility. It enables newer PackageDescription
APIs and aligns the project with the current Swift toolchain.