### PR TITLE
chore(pkg): fix Package.swift platforms array formatting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [
       .iOS(.v26.1),
       .ipadOS(.v26.1)
-    ]
+    ],
     dependencies: [
         .package(url: "https://github.com/flags-gg/swift.git", from: "v1.0.2"),
         .package(url: "https://github.com/clerk/clerk-ios.git", from: "0.71.4")


### PR DESCRIPTION
Adjust Package.swift to properly terminate the platforms array with a
trailing comma and closing bracket on its own line. This corrects a
syntax/formatting issue introduced in the manifest that could interfere
with package parsing or future diffs. No functional changes to
dependencies or platform versions are made.