### PR TITLE
chore(platforms): lower iOS deployment target to v18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Interviews",
     platforms: [
-      .iOS(.v26.1),
-      .ipadOS(.v26.1)
+      .iOS(.v18),
     ],
     dependencies: [
         .package(url: "https://github.com/flags-gg/swift.git", from: "v1.0.2"),


### PR DESCRIPTION
Update Package.swift to set the iOS minimum deployment target to
v18 and remove explicit iPadOS platform entry. This simplifies
platform configuration and broadens compatibility with older iOS
versions while avoiding redundant platform declarations. The change
ensures the package builds consistently on iOS targets without
separately specifying iPadOS.