### PR TITLE
chore(deps): bump flags-gg swift package to 1.0.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
       .iOS(.v18),
     ],
     dependencies: [
-        .package(url: "https://github.com/flags-gg/swift.git", from: "v1.0.2"),
+        .package(url: "https://github.com/flags-gg/swift.git", from: "1.0.3"),
         .package(url: "https://github.com/clerk/clerk-ios.git", from: "0.71.4")
     ],
     targets: [


### PR DESCRIPTION
Update Package.swift to use flags-gg Swift dependency version 1.0.3
instead of v1.0.2. This brings the project up to the latest patch
release of the flags-gg package, pulling in bug fixes and minor
improvements while preserving API.