### PR TITLE
feat(ui): wrap calendar in GeometryReader and fix colors

### DIFF
--- a/Interviews/UI/Utilities/Colors.swift
+++ b/Interviews/UI/Utilities/Colors.swift
@@ -41,10 +41,7 @@ func colorForOutcomeInterview(_ outcome: InterviewOutcome) -> Color {
         return .orange
     case .withdrew:
         return .gray
-        
     case .awaitingResponse:
-        return .yellow
-    default:
         return .yellow
     }
 }

--- a/Interviews/Views/ContentView.swift
+++ b/Interviews/Views/ContentView.swift
@@ -34,14 +34,14 @@ struct ContentView: View {
     @ViewBuilder
     private var iPadSidebar: some View {
         VStack(spacing: 0) {
-            CalendarView(selectedDate: $selectedDate)
-                .frame(maxHeight: 320)
-                .padding(.top, 8)
-                .padding(.bottom, 8)
-//                .onChange(of: selectedDate) { oldValue, newValue in
-//                    let oldStr = oldValue?.formatted(date: .abbreviated, time: .omitted) ?? "nil"
-//                    let newStr = newValue?.formatted(date: .abbreviated, time: .omitted) ?? "nil"
-//                }
+            GeometryReader { geo in
+                CalendarView(selectedDate: $selectedDate)
+                    .frame(maxHeight: 320)
+                    .padding(.top, geo.size.height * 0.01)
+                    .padding(.top, 8)
+                    .padding(.bottom, 8)
+            }
+            .frame(height: 320)
             Divider()
                 .padding(.vertical, 12)
             if statsEnabled {
@@ -81,10 +81,14 @@ struct ContentView: View {
     private var iPhoneMain: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                CalendarView(selectedDate: $selectedDate)
-                    .padding(.top, 8)
-                    .padding(.bottom, 8)
-                    .frame(maxHeight: 320)
+                GeometryReader { geo in
+                    CalendarView(selectedDate: $selectedDate)
+                        .padding(.top, geo.size.height * 0.01)
+                        .padding(.top, 8)
+                        .padding(.bottom, 8)
+                        .frame(maxHeight: 320)
+                }
+                .frame(height: 320)
                 Divider()
                     .padding(.vertical, 12)
                 InterviewListView(selectedDate: $selectedDate, searchText: searchText)


### PR DESCRIPTION
Wrap the CalendarView in a GeometryReader on both iPad sidebar and
iPhone main layouts so vertical padding can be calculated relative to
the container height. Constrain the reader to a fixed height of 320 to
keep the previous visual size, and preserve explicit top/bottom
padding. This stabilizes spacing across size classes and avoids the
commented debug code.

Also remove an extra blank line and unify the switch in Colors so the
awaitingResponse case returns .yellow consistently (clean up duplicate
branches).