### PR TITLE
feat(calendar): measure calendar height and simplify layout

### DIFF
--- a/Interviews/Services/GuestModeView.swift
+++ b/Interviews/Services/GuestModeView.swift
@@ -43,6 +43,7 @@ struct GuestModeBanner: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .foregroundStyle(.primary)
                     } else {
                         Button("Sign In") {
                             showingSignIn = true

--- a/Interviews/Views/CalendarView.swift
+++ b/Interviews/Views/CalendarView.swift
@@ -43,7 +43,6 @@ struct CalendarView: View {
                                     .font(.subheadline)
                                     .fontWeight(.medium)
                                     .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
                                     .foregroundStyle(.primary)
                             }
                             .glassEffect()

--- a/Interviews/Views/ContentView.swift
+++ b/Interviews/Views/ContentView.swift
@@ -77,32 +77,38 @@ struct ContentView: View {
     @ViewBuilder
     private var iPhoneMain: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                ZStack(alignment: .top) {
-                    CalendarView(selectedDate: $selectedDate)
-                        .frame(maxHeight: 320)
-                        .background(
-                            GeometryReader { innerGeo in
-                                Color.clear
-                                    .onAppear { calendarHeight = innerGeo.size.height }
-                                    .onChange(of: innerGeo.size.height) { _, newValue in
-                                        calendarHeight = newValue
-                                    }
-                            }
-                        )
+            GeometryReader { geo in
+                VStack(spacing: 0) {
+                    // Calendar section
+                    VStack(spacing: 0) {
+                        CalendarView(selectedDate: $selectedDate)
+                            .background(
+                                GeometryReader { innerGeo in
+                                    Color.clear
+                                        .onAppear { calendarHeight = innerGeo.size.height }
+                                        .onChange(of: innerGeo.size.height) { _, newValue in
+                                            calendarHeight = newValue
+                                        }
+                                }
+                            )
+                            .padding(.top, 8)
+                            .padding(.bottom, 8)
+                        Divider()
+                            .padding(.vertical, 12)
+                    }
+                    .accessibilityIdentifier("calendarSection")
+
+                    // List section takes remaining space and scrolls
+                    InterviewListView(selectedDate: $selectedDate, searchText: searchText)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        .accessibilityIdentifier("listSection")
                 }
-                .frame(height: 320)
-                .padding(.top, 8)
-                .padding(.bottom, 8)
-                Divider()
-                    .padding(.vertical, 12)
-                InterviewListView(selectedDate: $selectedDate, searchText: searchText)
-                    .padding(.top, max(0, calendarHeight - 320))
+                .foregroundStyle(.primary)
+                .frame(width: geo.size.width, height: geo.size.height)
             }
             .navigationTitle("Interview Planner")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { iPhoneToolbar }
-            .foregroundStyle(.primary)
         }
         .overlay(alignment: .bottomTrailing) {
             FloatingSearchControl(isExpanded: $showingSearch, text: $searchText)

--- a/Interviews/Views/ContentView.swift
+++ b/Interviews/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var showingAddInterview = false
     @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
     @State private var statsEnabled: Bool = false
+    @State private var calendarHeight: CGFloat = 0
     
     @Environment(\.flagsAgent) private var flagsAgent
 
@@ -34,14 +35,10 @@ struct ContentView: View {
     @ViewBuilder
     private var iPadSidebar: some View {
         VStack(spacing: 0) {
-            GeometryReader { geo in
-                CalendarView(selectedDate: $selectedDate)
-                    .frame(maxHeight: 320)
-                    .padding(.top, geo.size.height * 0.01)
-                    .padding(.top, 8)
-                    .padding(.bottom, 8)
-            }
-            .frame(height: 320)
+            CalendarView(selectedDate: $selectedDate)
+                .frame(maxHeight: 320)
+                .padding(.top, 8)
+                .padding(.bottom, 8)
             Divider()
                 .padding(.vertical, 12)
             if statsEnabled {
@@ -81,17 +78,26 @@ struct ContentView: View {
     private var iPhoneMain: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                GeometryReader { geo in
+                ZStack(alignment: .top) {
                     CalendarView(selectedDate: $selectedDate)
-                        .padding(.top, geo.size.height * 0.01)
-                        .padding(.top, 8)
-                        .padding(.bottom, 8)
                         .frame(maxHeight: 320)
+                        .background(
+                            GeometryReader { innerGeo in
+                                Color.clear
+                                    .onAppear { calendarHeight = innerGeo.size.height }
+                                    .onChange(of: innerGeo.size.height) { _, newValue in
+                                        calendarHeight = newValue
+                                    }
+                            }
+                        )
                 }
                 .frame(height: 320)
+                .padding(.top, 8)
+                .padding(.bottom, 8)
                 Divider()
                     .padding(.vertical, 12)
                 InterviewListView(selectedDate: $selectedDate, searchText: searchText)
+                    .padding(.top, max(0, calendarHeight - 320))
             }
             .navigationTitle("Interview Planner")
             .navigationBarTitleDisplayMode(.inline)

--- a/Interviews/Views/SettingsView.swift
+++ b/Interviews/Views/SettingsView.swift
@@ -119,6 +119,7 @@ struct SettingsView: View {
                     await performSync()
                 }
             }
+            .foregroundStyle(.primary)
         }
     }
     
@@ -128,6 +129,7 @@ struct SettingsView: View {
                 await showDatabaseInfo()
             }
         }
+        .foregroundStyle(.primary)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Introduce calendarHeight @State to track the rendered calendar height
and remove unnecessary GeometryReader wrappers around CalendarView. Use
a background GeometryReader on iPhone to capture and update calendar
height on appear and when it changes. Simpl iPad sidebar by removing
the outer GeometryReader and redundant top padding computation.

Apply the measured height to the interview list on iPhone by adding
top padding equal to max(0, calendarHeight - 320) so the list content
aligns correctly when the calendar size changes. These changes reduce
layout complexity and ensure consistent spacing between calendar and
list across device sizes.